### PR TITLE
feat(treefmt): reconcile to fleet canon + nix fmt via treefmt

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -1,50 +1,9 @@
 {
   pkgs,
-  imports,
   lib,
   config,
-  inputs,
   ...
 }:
-let
-  # Fetch and patch Codecov CLI binary for NixOS
-  codecov-cli-bin = pkgs.stdenv.mkDerivation rec {
-    pname = "codecov-cli";
-    version = "0.7.5";
-
-    src = pkgs.fetchurl {
-      url = "https://cli.codecov.io/latest/linux/codecov";
-      sha256 = "SppNUN8ct5Yinif43MKSv1U4d5zZBoUbN+s2EgKkPc4=";
-    };
-
-    dontUnpack = true;
-
-    nativeBuildInputs = [ pkgs.autoPatchelfHook ];
-
-    # Runtime dependencies the binary needs
-    buildInputs = [
-      pkgs.stdenv.cc.cc.lib # libstdc++
-      pkgs.zlib
-      pkgs.glibc
-    ];
-
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/bin
-      cp $src $out/bin/codecov
-      chmod +x $out/bin/codecov
-      runHook postInstall
-    '';
-
-    meta = with lib; {
-      description = "Codecov CLI";
-      homepage = "https://cli.codecov.io";
-      license = licenses.asl20;
-      platforms = platforms.linux;
-    };
-  };
-
-in
 {
   dotenv.enable = true;
   difftastic.enable = true;
@@ -219,7 +178,7 @@ in
     echo 💡 Helper scripts to ease development process:
     echo
     ${pkgs.gnused}/bin/sed -e 's| |••|g' -e 's|=| |' <<EOF | ${pkgs.util-linuxMinimal}/bin/column -t | ${pkgs.gnused}/bin/sed -e 's|^|• |' -e 's|••| |g'
-    ${lib.generators.toKeyValue { } (lib.mapAttrs (name: value: value.description) config.scripts)}
+    ${lib.generators.toKeyValue { } (lib.mapAttrs (_name: value: value.description) config.scripts)}
     EOF
     echo
   '';

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,5 @@
 {
-  description =
-    "A post-commit hook that saves commits to a specific file & directory";
+  description = "A post-commit hook that saves commits to a specific file & directory";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
@@ -8,8 +7,15 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      nixpkgs,
+      rust-overlay,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
@@ -21,7 +27,26 @@
           cargo = rustVersion;
           rustc = rustVersion;
         };
-      in {
+      in
+      {
+        # `nix fmt` runs treefmt against ./treefmt.toml - the same config the
+        # pre-commit hook uses. The toolchain comes from this flake's single
+        # nixpkgs (unstable) so nix fmt is internally consistent (the L23 fleet
+        # mitigation: pin the fmt toolchain to one nixpkgs source).
+        formatter = pkgs.writeShellApplication {
+          name = "treefmt-fmt";
+          runtimeInputs = [
+            pkgs.treefmt
+            pkgs.git
+            pkgs.nixfmt
+            pkgs.deadnix
+            pkgs.rustfmt
+            pkgs.toml-sort
+            pkgs.yamlfmt
+          ];
+          text = "exec treefmt \"$@\"";
+        };
+
         packages.default = rustPlatform.buildRustPackage {
           pname = "rusty-commit-saver";
           version = "4.15.1";
@@ -29,7 +54,10 @@
           cargoLock.lockFile = ./Cargo.lock;
 
           nativeBuildInputs = with pkgs; [ pkg-config ];
-          buildInputs = with pkgs; [ openssl openssl.dev ];
+          buildInputs = with pkgs; [
+            openssl
+            openssl.dev
+          ];
 
           OPENSSL_NO_VENDOR = 1;
           PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
@@ -54,5 +82,6 @@
           PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
           OPENSSL_NO_VENDOR = 1;
         };
-      });
+      }
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,10 @@
 //!
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
+use rusty_commit_saver::vim_commit::CommitSaver;
 use rusty_commit_saver::vim_commit::check_diary_path_exists;
 use rusty_commit_saver::vim_commit::create_diary_file;
 use rusty_commit_saver::vim_commit::create_directories_for_new_entry;
-use rusty_commit_saver::vim_commit::CommitSaver;
 
 use rusty_commit_saver::config::GlobalVars;
 
@@ -408,8 +408,8 @@ mod main_tests {
     }
 
     #[test]
-    fn test_create_directories_for_new_entry_with_existing_dirs(
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    fn test_create_directories_for_new_entry_with_existing_dirs()
+    -> Result<(), Box<dyn std::error::Error>> {
         let temp_dir = tempdir()?;
         let nested_path = temp_dir
             .path()

--- a/src/vim_commit.rs
+++ b/src/vim_commit.rs
@@ -926,9 +926,11 @@ mod commit_saver_tests {
         assert!(result.contains("2023"));
         assert!(result.contains("12-December"));
         // assert!(result.ends_with(".md"));
-        assert!(std::path::Path::new(&result)
-            .extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("md")));
+        assert!(
+            std::path::Path::new(&result)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+        );
     }
 
     #[test]

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,27 +1,121 @@
+# ==========================================================================
+# treefmt config - derived from the DevBoostrapper fleet canon
+# (treefmt.canonical.toml), kept verbatim.
+#
+# One file fits all: `allow-missing-formatter = true` means only the formatter
+# BINARIES for the languages this repo uses need to be present (via the devShell
+# / git-hooks); the rest are silently skipped. Tables stay alphabetically named
+# so treefmt / toml-sort keep this file stable.
+#
+# See DevBoostrapper TREEFMT_STANDARD.md for the fleet rationale and wiring.
+# ==========================================================================
+
+# Only walk git-tracked files (respects .gitignore).
+walk = "git"
+# Never hard-fail when a formatter binary is missing - keeps this one canonical
+# file usable across repos with different toolchains.
 allow-missing-formatter = true
 verbose = 1
-walk = "git"
+# Safe excludes, baked into the canon so every downstream repo inherits them.
+# These matter for TRACKED-but-vendored paths (e.g. career-ops commits a
+# vendored node_modules) that `walk = "git"` would otherwise still format.
+excludes = [
+  "**/node_modules/**",
+  "**/vendor/**",
+  "result",
+  "result-*",
+  "**/target/**",
+  ".direnv/**",
+  ".devenv/**",
+  "**/.git/**",
+  "**/*.min.js",
+  "**/*.min.css",
+  "**/copier.yaml",
+  "**/copier.yml"
+]
 
-[formatter.nixfmt-classic]
-command = "nixfmt"
-excludes = []
+# Nix: deadnix strips dead bindings first (priority 1), then nixfmt formats.
+[formatter.deadnix]
+command = "deadnix"
+options = ["--edit"]
 includes = ["*.nix"]
-options = []
+priority = 1
 
+# Go: gofumpt is a strict superset of gofmt.
+[formatter.gofumpt]
+command = "gofumpt"
+options = ["-w"]
+includes = ["*.go"]
+
+# Go: goimports fixes import grouping/ordering.
+[formatter.goimports]
+command = "goimports"
+options = ["-w"]
+includes = ["*.go"]
+
+# Markdown: MD013 (line length) disabled - prose wrapping is the author's call.
+[formatter.markdownlint]
+command = "markdownlint"
+options = ["--fix", "--disable", "MD013"]
+includes = ["*.md"]
+
+# Nix: the settled fleet nix formatter (alejandra is out).
+[formatter.nixfmt]
+command = "nixfmt"
+options = ["--width=100"]
+includes = ["*.nix"]
+
+# JavaScript / TypeScript / web.
+[formatter.prettier]
+command = "prettier"
+options = ["--write"]
+includes = [
+  "*.js",
+  "*.jsx",
+  "*.ts",
+  "*.tsx",
+  "*.json",
+  "*.css",
+  "*.scss",
+  "*.html"
+]
+
+# Python: ruff lint-fix. No black - ruff format (below) supersedes it.
+[formatter.ruff-check]
+command = "ruff"
+options = ["check", "--fix"]
+includes = ["*.py", "*.pyi"]
+
+# Python: ruff formatter.
+[formatter.ruff-format]
+command = "ruff"
+options = ["format"]
+includes = ["*.py", "*.pyi"]
+
+# Rust.
 [formatter.rustfmt]
 command = "rustfmt"
-excludes = []
+options = ["--edition", "2024", "--config", "skip_children=true"]
 includes = ["*.rs"]
-options = ["--config", "skip_children=true", "--edition", "2024"]
 
+# Shell: 2-space indent.
+[formatter.shfmt]
+command = "shfmt"
+options = ["-i", "2", "-w"]
+includes = ["*.sh"]
+
+# LaTeX.
+[formatter.tex-fmt]
+command = "tex-fmt"
+includes = ["*.tex", "*.bib", "*.cls", "*.sty"]
+
+# TOML.
 [formatter.toml-sort]
 command = "toml-sort"
-excludes = []
-includes = ["*.toml"]
 options = ["-i"]
+includes = ["*.toml"]
 
+# YAML.
 [formatter.yamlfmt]
 command = "yamlfmt"
-excludes = []
 includes = ["*.yaml", "*.yml"]
-options = []


### PR DESCRIPTION
Reconcile rusty-commit-saver to the treefmt fleet canon (lane L25).

- treefmt.toml: formatter tables byte-identical to the DevBoostrapper
  canon; only the header comment relabels it as a derived copy.
- flake.nix: gains a formatter output (treefmt wrapper on ./treefmt.toml,
  toolchain from the flake own unstable nixpkgs) so nix fmt is self-consistent.
- mechanical reformat: devenv.nix (nixfmt/deadnix) + src/*.rs (rustfmt 2024).
- deadnix dropped self from the flake outputs args; restored via ... so Nix
  can still pass self (nix flake check was failing otherwise).

Verified: nix flake check EXIT=0; nix build .#default green with doCheck
(tests pass, changes semantically inert); nix fmt idempotent (0 changed);
nix fmt and the real pre-commit hook produce identical output.

Gated by ARCHON; direct push blocked by the master protection ruleset, so
landing via PR to satisfy the required status checks.
