### PR TITLE
chore(deps): bump log to 0.4.33 and harden CI audit/codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: coverage
           name: Code Coverage
+          fail_ci_if_error: false
+          verbose: true
       - name: 📊 Upload test results to Codecov
         if: always() && hashFiles('junit.xml') != ''
         uses: codecov/codecov-action@v5
@@ -72,3 +74,5 @@ jobs:
           flags: unittests
           name: Unit Tests
           report_type: test_results
+          fail_ci_if_error: false
+          verbose: true

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -24,7 +24,9 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v4
-      - name: 🔐 Security Audit
-        uses: rustsec/audit-check@v2
+      - name: 📦 Install cargo-audit
+        uses: taiki-e/install-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          tool: cargo-audit
+      - name: 🔐 Security Audit
+        run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,9 +407,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "markup"


### PR DESCRIPTION
## What

- Bump `log` 0.4.32 → 0.4.33 (supersedes #65)
- Fix the Security Audit job: install `cargo-audit` as a prebuilt
  binary via `taiki-e/install-action` instead of compiling it from
  source (the source build was failing with cargo exit 101)
- Make Codecov uploads verbose and explicitly non-fatal

## Why

#65 was blocked indefinitely by the required `codecov/patch` check —
Codecov received the upload but its backend never processed the commit
(`state: null`) and never posted the status. This PR carries the same
log bump plus CI hardening on a fresh branch.

## Note

`codecov/patch` should be made optional in the ruleset (repo admin
action) so it stops hard-blocking merges when Codecov stalls.
