### PR TITLE
fix(devenv): write claude hook logs to .claude dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /target
 
 # nWave / Claude Code: local logs, coverage output, transient DES session state
-claude/*.log
+.claude/*.log
 lcov.info
 **/.develop-progress.json
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -54,7 +54,7 @@
         enable = true;
         name = "Log Claude notifications";
         hookType = "Notification";
-        command = ''echo "Claude notification received" >> ./claude/claude.log'';
+        command = ''mkdir -p .claude && echo "Claude notification received" >> .claude/claude.log'';
       };
 
       # Track completion (Stop hook)
@@ -62,7 +62,7 @@
         enable = true;
         name = "Track when Claude finishes";
         hookType = "Stop";
-        command = ''echo "Claude finished at $(date)" >> ./claude/claude-sessions.log'';
+        command = ''mkdir -p .claude && echo "Claude finished at $(date)" >> .claude/claude-sessions.log'';
       };
 
       # Subagent monitoring (SubagentStop hook)
@@ -70,7 +70,7 @@
         enable = true;
         name = "Log subagent completion";
         hookType = "SubagentStop";
-        command = ''echo "Subagent task completed" >> ./claude/subagent.log'';
+        command = ''mkdir -p .claude && echo "Subagent task completed" >> .claude/subagent.log'';
       };
     };
   };


### PR DESCRIPTION
## What

Fixes the Claude Code git-hook log paths in `devenv.nix`.

## Why

The Notification, Stop and SubagentStop hooks appended to `./claude/*.log`, but
that directory does not exist (the real one is `.claude`), so every hook failed
with a no-such-file error on each run.

## Change

- point all three hook commands at `.claude/*.log`
- guard each with `mkdir -p .claude` so they never fail cold
- fix `.gitignore` pattern `claude/*.log` → `.claude/*.log` so the logs are
  actually ignored

## Note

After merge, run `direnv reload` locally to regenerate `.claude/settings.json`
from the updated `devenv.nix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
