### PR TITLE
feat(config): add per-repo exclude list to skip commit capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,31 @@ Your commit will be appended to, where Obsidian should be:
 - **`.pre-commit-config.yaml`** defines all pre-commit checks
 - **`treefmt.toml`** configures `treefmt` and formatters
 
+### Runtime config (INI)
+
+Runtime settings live in an INI file at
+`~/.config/rusty-commit-saver/rusty-commit-saver.ini`:
+
+```ini
+[obsidian]
+root_path_dir = ~/Documents/Obsidian
+commit_path = Diaries/Commits
+
+[templates]
+commit_date_path = %Y/%m-%B/%F.md
+commit_datetime = %H:%M:%S
+
+# Optional: repositories to skip, by working-directory name (comma-separated).
+# A commit made in one of these repos writes nothing to the diary.
+[exclude]
+repos = claude-src
+```
+
+The `[exclude]` section is optional. Each entry is matched, case-sensitively,
+against the committing repository's working-directory name (e.g. `claude-src`
+for a repo checked out at `~/src/claude-src`) — so it holds no matter which
+subdirectory the commit is made from.
+
 ---
 
 ## Roadmap & Improvements 📈

--- a/rusty-commit-saver.ini
+++ b/rusty-commit-saver.ini
@@ -6,3 +6,8 @@ commit_path = /📅 Diaries/0. Journal
 [templates]
 commit_date_path = %Y/%m-%B/%F.md
 commit_datetime = %H:%M:%S
+
+# Optional: repositories to skip, by working-directory name (comma-separated).
+# A commit made in one of these repos writes nothing to the diary.
+[exclude]
+repos = claude-src

--- a/src/config.rs
+++ b/src/config.rs
@@ -242,6 +242,22 @@ pub struct GlobalVars {
     /// commit_datetime = %Y-%m-%d %H:%M:%S
     /// ```
     template_commit_datetime: OnceCell<String>,
+
+    /// Repository names to exclude from commit capture.
+    ///
+    /// When the current repository's working-directory name matches an entry in
+    /// this list, the post-commit run skips cleanly and writes nothing to the
+    /// diary. Populated from the optional `[exclude]` section; empty when that
+    /// section is absent.
+    ///
+    /// # Configuration
+    ///
+    /// Loaded from the INI file (comma-separated, optional):
+    /// ```text
+    /// [exclude]
+    /// repos = claude-src, some-other-repo
+    /// ```
+    excluded_repos: OnceCell<Vec<String>>,
 }
 
 impl GlobalVars {
@@ -289,6 +305,8 @@ impl GlobalVars {
 
             template_commit_date_path: OnceCell::new(),
             template_commit_datetime: OnceCell::new(),
+
+            excluded_repos: OnceCell::new(),
         }
     }
 
@@ -596,21 +614,24 @@ impl GlobalVars {
     fn get_sections_from_config(&self) -> Vec<String> {
         info!("[GlobalVars::get_sections_from_config()] Getting sections from config");
         let sections = self.get_config().sections();
-        let sections_len = sections.len(); // Extract to variable
 
-        info!("[GlobalVars::get_sections_from_config()] Checking validity of number of sections.");
-        if sections_len == 2 {
+        info!("[GlobalVars::get_sections_from_config()] Checking validity of config sections.");
+        let has_required = ["obsidian", "templates"]
+            .iter()
+            .all(|required| sections.iter().any(|s| s == required));
+        let all_known = sections
+            .iter()
+            .all(|s| ["obsidian", "templates", "exclude"].contains(&s.as_str()));
+
+        if has_required && all_known {
             sections
         } else {
             error!(
                 // LCOV_EXCL_START
-                "[GlobalVars::get_sections_from_config()] Sections Len must be 2, we have: {sections_len:?}"
-            );
-            error!(
                 "[GlobalVars::get_sections_from_config()] These are the sections found: {sections:?}"
             ); // LCOV_EXCL_STOP
             panic!(
-                "[GlobalVars::get_sections_from_config()] config has the wrong number of sections."
+                "[GlobalVars::get_sections_from_config()] config must have [obsidian] and [templates], plus an optional [exclude]."
             )
         }
     }
@@ -656,14 +677,12 @@ impl GlobalVars {
                 info!("[GlobalVars::set_obsidian_vars()] Setting 'templates' section variables.");
                 self.set_templates_commit_date_path(&section);
                 self.set_templates_datetime(&section);
-            } else {
-                error!(
-                    "[GlobalVars::set_obsidian_vars()] Trying to set other sections is not supported."
-                );
-                panic!(
-                    "[GlobalVars::set_obsidian_vars()] Trying to set other sections is not supported."
-                )
+            } else if section == "exclude" {
+                info!("[GlobalVars::set_obsidian_vars()] Setting 'exclude' section variables.");
+                self.set_excluded_repos(&section);
             }
+            // No `else`: `get_sections_from_config()` is the single validation
+            // point and has already rejected any unknown section.
         }
     }
 
@@ -697,6 +716,55 @@ impl GlobalVars {
         self.template_commit_datetime
             .set(key)
             .expect("Could not set the template_commit_datetime GlobalVars");
+    }
+
+    /// Sets the `excluded_repos` field from the optional `[exclude]` section.
+    ///
+    /// Reads the `repos` key, parses it as a comma-separated list of repository
+    /// names, and stores the result. A missing `repos` key yields an empty list.
+    ///
+    /// # Arguments
+    ///
+    /// * `section` - Should be `"exclude"` (validated by caller)
+    ///
+    /// # Expected INI Key
+    ///
+    /// ```text
+    /// [exclude]
+    /// repos = claude-src, some-other-repo
+    /// ```
+    fn set_excluded_repos(&self, section: &str) {
+        info!("[GlobalVars::set_excluded_repos()]: Setting the excluded repos list.");
+        let raw = self
+            .get_key_from_section_from_ini(section, "repos")
+            .unwrap_or_default();
+
+        self.excluded_repos
+            .set(parse_exclude_repos(&raw))
+            .expect("Could not set the excluded_repos in GlobalVars");
+    }
+
+    /// Returns the list of repository names excluded from commit capture.
+    ///
+    /// Reads the value populated from the optional `[exclude]` section. When that
+    /// section (or its `repos` key) is absent, returns an empty list — meaning no
+    /// repository is excluded.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<String>` of excluded repository names (working-directory names).
+    ///
+    /// # Configuration Source
+    ///
+    /// Read from the INI file:
+    /// ```text
+    /// [exclude]
+    /// repos = claude-src
+    /// ```
+    #[must_use]
+    pub fn get_excluded_repos(&self) -> Vec<String> {
+        info!("[GlobalVars::get_excluded_repos()]: Getting excluded repos list.");
+        self.excluded_repos.get().cloned().unwrap_or_default()
     }
 
     /// Sets the `template_commit_date_path` field from the `[templates]` section.
@@ -1191,6 +1259,36 @@ fn set_proper_home_dir(cfg_str: &str) -> String {
     cfg_str.replace('~', &home_dir)
 }
 
+/// Parses a comma-separated list of repository names into a clean vector.
+///
+/// Each entry is trimmed of surrounding whitespace and empty entries are
+/// dropped, so trailing commas and stray spaces are tolerated.
+///
+/// # Arguments
+///
+/// * `raw` - The raw comma-separated value (e.g. `"claude-src, other-repo"`)
+///
+/// # Returns
+///
+/// A `Vec<String>` with one entry per non-empty, trimmed repository name.
+///
+/// # Examples
+///
+/// ```ignore
+/// use rusty_commit_saver::config::parse_exclude_repos;
+///
+/// assert_eq!(parse_exclude_repos("claude-src, foo"), vec!["claude-src", "foo"]);
+/// assert_eq!(parse_exclude_repos("  "), Vec::<String>::new());
+/// ```
+#[must_use]
+pub fn parse_exclude_repos(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod global_vars_tests {
@@ -1250,7 +1348,7 @@ mod global_vars_tests {
             .downcast_ref::<&str>()
             .expect("Panic message should be &str");
         assert!(
-            msg.contains("wrong number of sections"),
+            msg.contains("must have [obsidian] and [templates]"),
             "Unexpected panic message: {msg}"
         );
     }
@@ -1518,7 +1616,7 @@ mod global_vars_tests {
     }
 
     #[test]
-    #[should_panic(expected = "Trying to set other sections is not supported")]
+    #[should_panic(expected = "must have [obsidian] and [templates]")]
     fn test_set_obsidian_vars_invalid_section() {
         let mut config = Ini::new();
         // Add correct number of sections (2) but with wrong name
@@ -2306,5 +2404,132 @@ commit_datetime = %Y-%m-%d %H:%M:%S
 
         // Cleanup (won't run due to panic, but good practice)
         fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644)).unwrap();
+    }
+
+    #[test]
+    fn test_parse_exclude_repos_basic() {
+        assert_eq!(
+            parse_exclude_repos("claude-src, other-repo"),
+            vec!["claude-src".to_string(), "other-repo".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_parse_exclude_repos_trims_and_drops_empties() {
+        // Extra spaces, trailing comma, and an empty middle entry are all cleaned.
+        assert_eq!(
+            parse_exclude_repos("  claude-src , , foo,"),
+            vec!["claude-src".to_string(), "foo".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_parse_exclude_repos_empty_input() {
+        assert!(parse_exclude_repos("   ").is_empty());
+        assert!(parse_exclude_repos("").is_empty());
+    }
+
+    #[test]
+    fn test_parse_exclude_repos_single_entry() {
+        assert_eq!(
+            parse_exclude_repos("claude-src"),
+            vec!["claude-src".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_get_excluded_repos_defaults_empty_when_unset() {
+        // No [exclude] section set: getter yields an empty list, not a panic.
+        let global_vars = GlobalVars::new();
+        assert!(global_vars.get_excluded_repos().is_empty());
+    }
+
+    #[test]
+    fn test_set_and_get_excluded_repos() {
+        let mut config = Ini::new();
+        config.set("exclude", "repos", Some("claude-src, foo".to_string()));
+
+        let global_vars = GlobalVars::new();
+        global_vars.config.set(config).unwrap();
+        global_vars.set_excluded_repos("exclude");
+
+        assert_eq!(
+            global_vars.get_excluded_repos(),
+            vec!["claude-src".to_string(), "foo".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_set_excluded_repos_missing_key_is_empty() {
+        // [exclude] present but no `repos` key -> empty list, no panic.
+        let mut config = Ini::new();
+        config.set("exclude", "unrelated", Some("value".to_string()));
+
+        let global_vars = GlobalVars::new();
+        global_vars.config.set(config).unwrap();
+        global_vars.set_excluded_repos("exclude");
+
+        assert!(global_vars.get_excluded_repos().is_empty());
+    }
+
+    #[test]
+    fn test_get_sections_accepts_optional_exclude_section() {
+        // obsidian + templates + exclude is now valid (exclude is optional).
+        let mut config = Ini::new();
+        config.set("obsidian", "root_path_dir", Some("/tmp/test".to_string()));
+        config.set("templates", "commit_date_path", Some("%Y.md".to_string()));
+        config.set("exclude", "repos", Some("claude-src".to_string()));
+
+        let global_vars = GlobalVars::new();
+        global_vars.config.set(config).unwrap();
+
+        let sections = global_vars.get_sections_from_config();
+        assert_eq!(sections.len(), 3);
+        assert!(sections.contains(&"exclude".to_string()));
+    }
+
+    #[test]
+    fn test_set_obsidian_vars_populates_exclude_section() {
+        // Full set_obsidian_vars path with all three sections present.
+        let mut config = Ini::new();
+        config.set(
+            "obsidian",
+            "root_path_dir",
+            Some("/home/user/Obsidian".to_string()),
+        );
+        config.set(
+            "obsidian",
+            "commit_path",
+            Some("Diaries/Commits".to_string()),
+        );
+        config.set(
+            "templates",
+            "commit_date_path",
+            Some("%Y-%m-%d.md".to_string()),
+        );
+        config.set("templates", "commit_datetime", Some("%H:%M:%S".to_string()));
+        config.set("exclude", "repos", Some("claude-src".to_string()));
+
+        let global_vars = GlobalVars::new();
+        global_vars.config.set(config).unwrap();
+        global_vars.set_obsidian_vars();
+
+        assert_eq!(
+            global_vars.get_excluded_repos(),
+            vec!["claude-src".to_string()]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "must have [obsidian] and [templates]")]
+    fn test_get_sections_rejects_missing_required_section() {
+        // exclude alone (no obsidian/templates) is still invalid.
+        let mut config = Ini::new();
+        config.set("exclude", "repos", Some("claude-src".to_string()));
+        config.set("templates", "commit_date_path", Some("%Y.md".to_string()));
+
+        let global_vars = GlobalVars::new();
+        global_vars.config.set(config).unwrap();
+        let _ = global_vars.get_sections_from_config();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,10 @@
 //! let obsidian_root = global_vars.get_obsidian_root_path_dir();
 //! let commit_path = global_vars.get_obsidian_commit_path();
 //! let date_template = global_vars.get_template_commit_date_path();
+//! let excluded_repos = global_vars.get_excluded_repos();
 //!
-//! // Save the commit
-//! run_commit_saver(obsidian_root, &commit_path, &date_template).unwrap();
+//! // Save the commit (skips cleanly if this repo is excluded)
+//! run_commit_saver(obsidian_root, &commit_path, &date_template, &excluded_repos).unwrap();
 //! ```
 //!
 //! ## Configuration
@@ -48,6 +49,10 @@
 //! [templates]
 //! commit_date_path = %Y/%m-%B/%F.md
 //! commit_datetime = %Y-%m-%d %H:%M:%S
+//!
+//! # Optional: repos to skip (comma-separated working-directory names)
+//! [exclude]
+//! repos = claude-src
 //! ```
 //!
 //! ## Modules

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use rusty_commit_saver::vim_commit::CommitSaver;
 use rusty_commit_saver::vim_commit::check_diary_path_exists;
 use rusty_commit_saver::vim_commit::create_diary_file;
 use rusty_commit_saver::vim_commit::create_directories_for_new_entry;
+use rusty_commit_saver::vim_commit::current_repo_workdir_name;
+use rusty_commit_saver::vim_commit::is_repo_excluded;
 
 use rusty_commit_saver::config::GlobalVars;
 
@@ -31,6 +33,8 @@ use std::path::PathBuf;
 /// * `obsidian_root_path_dir` - Base directory for Obsidian vault (e.g., `/home/user/Obsidian`)
 /// * `obsidian_commit_path` - Subdirectory for commits (e.g., `Diaries/Commits`)
 /// * `template_commit_date_path` - Chrono format for date hierarchy (e.g., `%Y/%m-%B/%F.md`)
+/// * `excluded_repos` - Repository names to skip; when the current repo's
+///   working-directory name matches, the run returns `Ok(())` without writing
 ///
 /// # Returns
 ///
@@ -56,7 +60,9 @@ use std::path::PathBuf;
 /// let commit_path = PathBuf::from("Diaries/Commits");
 /// let date_template = "%Y/%m-%B/%F.md"; // YYYY/MM-MonthName/YYYY-MM-DD.md
 ///
-/// match run_commit_saver(obsidian_root, &commit_path, date_template) {
+/// let excluded_repos: Vec<String> = vec![]; // e.g. vec!["claude-src".to_string()]
+///
+/// match run_commit_saver(obsidian_root, &commit_path, date_template, &excluded_repos) {
 ///     Ok(()) => println!("✓ Commit successfully logged!"),
 ///     Err(e) => eprintln!("✗ Failed to log commit: {}", e),
 /// }
@@ -96,7 +102,17 @@ pub fn run_commit_saver(
     obsidian_root_path_dir: PathBuf,
     obsidian_commit_path: &Path,
     template_commit_date_path: &str,
+    excluded_repos: &[String],
 ) -> Result<(), Box<dyn Error>> {
+    if let Some(repo_name) = current_repo_workdir_name() {
+        if is_repo_excluded(&repo_name, excluded_repos) {
+            info!(
+                "[run_commit_saver()]: repo '{repo_name}' is in the exclude list; skipping commit capture."
+            );
+            return Ok(());
+        }
+    }
+
     info!("[run_commit_saver()]: Instanciating CommitSaver Struct");
     let mut commit_saver_struct = CommitSaver::new();
 
@@ -145,11 +161,13 @@ fn main() {
     let obsidian_root_path_dir = global_vars.get_obsidian_root_path_dir();
     let obsidian_commit_path = global_vars.get_obsidian_commit_path();
     let template_commit_date_path = global_vars.get_template_commit_date_path();
+    let excluded_repos = global_vars.get_excluded_repos();
 
     match run_commit_saver(
         obsidian_root_path_dir,
         &obsidian_commit_path,
         &template_commit_date_path,
+        &excluded_repos,
     ) {
         Ok(()) => (),
         Err(e) => {
@@ -276,7 +294,7 @@ mod main_tests {
 
         // This assumes we're in a git repo for CommitSaver::new() to work
         if Repository::discover("./").is_ok() {
-            let result = run_commit_saver(obsidian_root.clone(), &commit_path, date_template);
+            let result = run_commit_saver(obsidian_root.clone(), &commit_path, date_template, &[]);
 
             // Should succeed and create diary file
             assert!(result.is_ok());
@@ -300,7 +318,7 @@ mod main_tests {
 
         // Only run if we're in a git repo
         if Repository::discover("./").is_ok() {
-            let result = run_commit_saver(obsidian_root.clone(), &commit_path, date_template);
+            let result = run_commit_saver(obsidian_root.clone(), &commit_path, date_template, &[]);
 
             // Should succeed and create the missing directories
             assert!(result.is_ok());
@@ -321,10 +339,10 @@ mod main_tests {
         // Only run if in a git repo
         if Repository::discover("./").is_ok() {
             // First run - creates the file
-            run_commit_saver(obsidian_root.clone(), &commit_path, date_template)?;
+            run_commit_saver(obsidian_root.clone(), &commit_path, date_template, &[])?;
 
             // Second run - should append to existing file
-            let result = run_commit_saver(obsidian_root.clone(), &commit_path, date_template);
+            let result = run_commit_saver(obsidian_root.clone(), &commit_path, date_template, &[]);
             assert!(result.is_ok());
 
             // Verify file exists and has multiple entries
@@ -349,7 +367,7 @@ mod main_tests {
         // Only run if in a git repo
         if Repository::discover("./").is_ok() {
             // Create directory structure first
-            let result = run_commit_saver(obsidian_root.clone(), &commit_path, date_template);
+            let result = run_commit_saver(obsidian_root.clone(), &commit_path, date_template, &[]);
             assert!(result.is_ok());
 
             // Now make the directory read-only to trigger write errors on second run
@@ -439,7 +457,8 @@ mod main_tests {
         if Repository::discover("./").is_ok() {
             // Run three times - should be idempotent
             for _ in 0..3 {
-                let result = run_commit_saver(obsidian_root.clone(), &commit_path, date_template);
+                let result =
+                    run_commit_saver(obsidian_root.clone(), &commit_path, date_template, &[]);
                 assert!(result.is_ok());
             }
         }
@@ -467,11 +486,43 @@ mod main_tests {
         let date_template = "%Y/%m-%B/%d/%F.md";
 
         if Repository::discover("./").is_ok() {
-            let result = run_commit_saver(complex_root.clone(), &commit_path, date_template);
+            let result = run_commit_saver(complex_root.clone(), &commit_path, date_template, &[]);
             assert!(result.is_ok());
 
             // Verify deep directory structure was created
             assert!(complex_root.exists() || temp_dir.path().join("level1").exists());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_run_commit_saver_skips_excluded_repo() -> Result<(), Box<dyn std::error::Error>> {
+        use git2::Repository;
+
+        let temp_dir = tempdir()?;
+        let obsidian_root = temp_dir.path().to_path_buf();
+        let commit_path = PathBuf::from("Diaries/Commits");
+        let date_template = "%Y/%m-%B/%F.md";
+
+        // Exclude the repository the test suite itself runs in: the gate must
+        // short-circuit and write nothing to the Obsidian root.
+        if let Some(current_repo) = current_repo_workdir_name() {
+            if Repository::discover("./").is_ok() {
+                let excluded = vec![current_repo];
+                let result = run_commit_saver(
+                    obsidian_root.clone(),
+                    &commit_path,
+                    date_template,
+                    &excluded,
+                );
+
+                assert!(result.is_ok(), "excluded repo should skip cleanly");
+                assert!(
+                    !obsidian_root.join("Diaries").exists(),
+                    "excluded repo must not create any diary output"
+                );
+            }
         }
 
         Ok(())

--- a/src/vim_commit.rs
+++ b/src/vim_commit.rs
@@ -544,6 +544,59 @@ tags:\n"
     }
 }
 
+/// Returns the working-directory name of a Git repository.
+///
+/// This is the basename of the repository's work tree (e.g. `claude-src` for a
+/// repo checked out at `/home/user/src/claude-src`). It is the stable identity
+/// used for the exclude list, independent of which subdirectory a commit is made
+/// from.
+///
+/// # Returns
+///
+/// - `Some(name)` - The repository's working-directory basename
+/// - `None` - The repository is bare (no work tree) or the path has no basename
+#[must_use]
+pub fn repo_workdir_name(repo: &Repository) -> Option<String> {
+    repo.workdir()
+        .and_then(Path::file_name)
+        .map(|name| name.to_string_lossy().into_owned())
+}
+
+/// Returns the working-directory name of the Git repository at the current path.
+///
+/// Discovers the repository from the current directory (`./`) and returns its
+/// working-directory basename via [`repo_workdir_name`]. Returns `None` when no
+/// repository can be discovered.
+#[must_use]
+pub fn current_repo_workdir_name() -> Option<String> {
+    let repo = Repository::discover("./").ok()?;
+    repo_workdir_name(&repo)
+}
+
+/// Reports whether a repository name is present in the exclude list.
+///
+/// Matching is an exact, case-sensitive comparison of the repository's
+/// working-directory name against each configured entry.
+///
+/// # Arguments
+///
+/// * `repo_name` - The repository's working-directory name (see [`repo_workdir_name`])
+/// * `exclude_list` - The configured repository names to skip
+///
+/// # Examples
+///
+/// ```ignore
+/// use rusty_commit_saver::vim_commit::is_repo_excluded;
+///
+/// let list = vec!["claude-src".to_string()];
+/// assert!(is_repo_excluded("claude-src", &list));
+/// assert!(!is_repo_excluded("other-repo", &list));
+/// ```
+#[must_use]
+pub fn is_repo_excluded(repo_name: &str, exclude_list: &[String]) -> bool {
+    exclude_list.iter().any(|excluded| excluded == repo_name)
+}
+
 /// Extracts the parent directory from a file path.
 ///
 /// Returns a reference to the parent directory component of the given path.
@@ -1255,5 +1308,43 @@ mod commit_saver_tests {
             "get_parent_from_full_path should succeed on nested path"
         );
         assert_eq!(result.unwrap(), std::path::Path::new("/home/user"));
+    }
+
+    #[test]
+    fn test_repo_workdir_name_returns_basename() {
+        // A repo checked out at .../claude-src reports its name as "claude-src",
+        // no ambient current-directory dependency.
+        let temp_dir = tempdir().unwrap();
+        let repo_path = temp_dir.path().join("claude-src");
+        fs::create_dir(&repo_path).unwrap();
+        let repo = Repository::init(&repo_path).unwrap();
+
+        assert_eq!(repo_workdir_name(&repo).as_deref(), Some("claude-src"));
+    }
+
+    #[test]
+    fn test_is_repo_excluded_matches_exact_name() {
+        let list = vec!["claude-src".to_string(), "foo".to_string()];
+        assert!(is_repo_excluded("claude-src", &list));
+        assert!(is_repo_excluded("foo", &list));
+    }
+
+    #[test]
+    fn test_is_repo_excluded_rejects_non_member() {
+        let list = vec!["claude-src".to_string()];
+        assert!(!is_repo_excluded("rusty-commit-saver", &list));
+        // No partial / prefix matching.
+        assert!(!is_repo_excluded("claude-src-2", &list));
+    }
+
+    #[test]
+    fn test_is_repo_excluded_empty_list_excludes_nothing() {
+        assert!(!is_repo_excluded("claude-src", &[]));
+    }
+
+    #[test]
+    fn test_is_repo_excluded_is_case_sensitive() {
+        let list = vec!["claude-src".to_string()];
+        assert!(!is_repo_excluded("Claude-Src", &list));
     }
 }


### PR DESCRIPTION
## What

Adds an optional `[exclude]` section to the INI config so commits made in
listed repositories are skipped cleanly — nothing is written to the diary.
Retires the interim local `hooksPath` override that silenced the `claude-src`
daily-note flood.

## How

- New optional `[exclude]` section with a comma-separated `repos` key.
- Match key = the repo **working-directory name** (e.g. `claude-src`), so it
  holds regardless of which subdirectory the commit is made from, and needs
  no git remote. Exact, case-sensitive match.
- `run_commit_saver` returns `Ok(())` without writing when the current repo
  is excluded.
- Section validation relaxed: `[obsidian]` + `[templates]` required,
  `[exclude]` optional; unknown sections still rejected (single validation
  point).
- Seeded sample `rusty-commit-saver.ini`, `README`, and lib docs.

## Tests

`devenv shell -- pre-check` green: **123 pass, 1 skipped**, clippy clean,
release build ok. Added unit tests (parse / getter / setter / validator) and
a `run_commit_saver` skip integration test.

## Deploy note

Takes effect once the new binary is deployed; the live config already carries
an `[exclude]` section that the currently-installed 4.15.0 binary panics on.

Refs: mailbox baton L52
