### PR TITLE
ci: gate tracked-file formatting on treefmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,22 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
 jobs:
+  # Formatting gate. Runs the SAME treefmt.toml the pre-commit hook uses, via the
+  # flake's `formatter` output - self-contained, unlike devenv.nix, which imports
+  # from ~/devenv_shared and therefore cannot evaluate on a CI runner.
+  # `--ci` = --no-cache + --fail-on-change, so any unformatted tracked file is red.
+  formatting:
+    name: 🎨 Formatting (treefmt)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: ❄️ Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+      - name: 🎨 treefmt (fail on change)
+        run: nix fmt -- --ci
   quality-checks:
     name: 🛠️ Quality Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,8 +19,7 @@ jobs:
     name: 📚 Build Documentation
     runs-on: ubuntu-latest
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,13 @@
         # pre-commit hook uses. The toolchain comes from this flake's single
         # nixpkgs (unstable) so nix fmt is internally consistent (the L23 fleet
         # mitigation: pin the fmt toolchain to one nixpkgs source).
+        #
+        # INVARIANT: runtimeInputs must supply a binary for EVERY treefmt.toml
+        # formatter that matches a tracked file here. treefmt.toml sets
+        # `allow-missing-formatter = true` (fleet canon, one file fits all), so a
+        # missing binary is skipped silently - and the CI gate below would then
+        # pass without ever checking those files. Add a file type, add its
+        # formatter here.
         formatter = pkgs.writeShellApplication {
           name = "treefmt-fmt";
           runtimeInputs = [
@@ -43,6 +50,8 @@
             pkgs.rustfmt
             pkgs.toml-sort
             pkgs.yamlfmt
+            pkgs.markdownlint-cli # *.md
+            pkgs.shfmt # *.sh
           ];
           text = "exec treefmt \"$@\"";
         };


### PR DESCRIPTION
Fixes the repo formatter being red on master with nothing in CI to catch
it, so every lane inherited the failure.

## What

- reflow the `if:` folded scalar in `docs.yml` as yamlfmt writes it
  (semantic no-op — a `>-` block folds its lines with spaces anyway)
- add a `formatting` CI job running `nix fmt -- --ci`
  (`--ci` = `--no-cache` + `--fail-on-change`)
- give the flake `formatter` output `markdownlint-cli` and `shfmt`

## Why the flake change was needed

`treefmt.toml` sets `allow-missing-formatter = true` (fleet canon), so a
missing formatter binary is skipped **silently**. The flake formatter had
no markdownlint and no shfmt, so `nix fmt` covered 24 of 47 tracked files —
the gate would have passed vacuously on all 22 markdown files and the one
shell script. An invariant comment now records this beside `runtimeInputs`.

`devenv shell -- treefmt` (the pattern in `rusty_cv_creator`) is not usable
here: `devenv.nix` imports from `~/devenv_shared`, absent on a runner.

## Verification

| check | expected | result |
| --- | --- | --- |
| clean tree | exit 0 | ✅ |
| yaml regression | non-zero | ✅ |
| markdown regression | non-zero | ✅ |
| shell regression | non-zero | ✅ |

`actionlint` reports nothing on the new job. 151 tests pass, clippy
unchanged, `nix flake check` evaluates.

Refs: baton L87
